### PR TITLE
Add option to restore window border via screen edge listener

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build: clean
 
 uninstall:
 	@echo "Removing hide-titles script..."
-	@-plasmapkg2 -t kwinscript -r hide-titles.kwinscript
+	@-plasmapkg2 -t kwinscript -r hide-titles
 
 install: uninstall build
 	@echo "Installing hide-titles..."

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Removes the window title on:
 
 And never applies on windows that always start without window borders (ie, latte dock, Application Menu widget...).
 
+Bind "Hide Titles" to a screen edge listener to restore the border on the active window (can be re-hidden by exiting and then entering maximized).
+
 To-do list:
 
 * Let the user set up application exceptions.

--- a/metadata.desktop
+++ b/metadata.desktop
@@ -6,6 +6,7 @@ Type=Service
 
 X-Plasma-API=javascript
 X-Plasma-MainScript=code/main.js
+X-KWin-Border-Activate=true
 
 X-KDE-ServiceTypes=KWin/Script
 


### PR DESCRIPTION
A much easier way to get your title bar back than `alt + F3` and then messing with a menu. If you bind it to the top of your screen, just slide your cursor up and then you can immediately use the title bar.

Unfortunately, AFAIK there is no way to have the title bar hidden again automatically when your mouse goes back down (like on Mac), so you do have to close and then open maximization again.